### PR TITLE
use NAN for Node.js >=0.12 compatibility of native add-on

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -3,6 +3,7 @@
         "target_name": "binding",
         "sources": ["binding.cc"],
         "include_dirs": [
+            "<!(node -e \"require('nan')\")",
             "/opt/vc/include",
             "/opt/vc/include/interface/vcos/pthreads",
             "/opt/vc/include/interface/vmcs_host/linux"

--- a/package.json
+++ b/package.json
@@ -21,5 +21,9 @@
         "url": "https://github.com/loyd/node-vcgencmd/issues"
     },
 
-    "homepage": "https://github.com/loyd/node-vcgencmd"
+    "homepage": "https://github.com/loyd/node-vcgencmd",
+
+    "dependencies": {
+        "nan": "^2.0.9"
+    }
 }


### PR DESCRIPTION
I've ported the binding.cc to NAN to be compatible with all supported node versions.
